### PR TITLE
A proposed fix for supporting AMD-style modules.

### DIFF
--- a/patterns.js
+++ b/patterns.js
@@ -115,6 +115,12 @@ var traverse = function (node) {
         return result ? false : true;
       });
       return result;
+    } else if (node.args && node.args.length) {
+        node.args.every(function (n) {
+            result = traverse(n);
+            return result ? false : true;
+        });
+        return result;
     } else if (node.body) {
       return traverse(node.body);
     } else if (node.expression) {

--- a/test/fixtures/amd.js
+++ b/test/fixtures/amd.js
@@ -1,0 +1,3 @@
+define(function (require, exports, module) {
+exports.version = "0.9.0";
+});

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,7 @@ test('reading version numbers from simple text fixtures', function (t) {
   t.equal(getVersion('fixtures/assigned.js'), '0.0.7', "module.exports.version assignment");
   t.equal(getVersion('fixtures/literal.js'), '0.10.29', "object literal returned from a module function");
   t.equal(getVersion('fixtures/assigned-literal.js'), '7.7.7', "object literal assigned to exports");
+  t.equal(getVersion('fixtures/amd.js'), '0.9.0', "object literal assigned to exports in AMD-style module");
   t.end();
 });
 


### PR DESCRIPTION
Thank you for the useful tool. I've tried using it for code I've designed to load in Node.js **and** in through RequireJS. Unfortunately, semver-sync 1.1.1 crashes when trying to extract version information from my file. The amd.js fixture this patch adds shows a bare-bones version of what I'm talking about. If you run the test suite without the patch to patterns.js, the test will fail.

Truth be told I would not be surprised if the patch needs adjustment because I'm not familiar at all with the data structure provided by Uglify. At the very least, my patch should show what the problem is.

Thanks!
