### PR TITLE
Fixed typographical error, changed accidentaly to accidentally in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ semver-sync -v
 [OK] Everything is in sync, with version number 1.2.3
 ````
 
-If you accidentaly change the version number in one of the sources, or forget to update it, you'll see an error:
+If you accidentally change the version number in one of the sources, or forget to update it, you'll see an error:
 
 ````
 semver-sync -v


### PR DESCRIPTION
cimi, I've corrected a typographical error in the documentation of the [semver-sync](https://github.com/cimi/semver-sync) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.