### PR TITLE
Add support for TypeScript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var exec = require('child_process').exec
   , fs = require('fs')
   , semver = require('semver')
-  , patterns = require('./patterns');
+  , patterns = require('./patterns')
+  , tspatterns = require("./tspatterns");
 
 var DEFAULT_SEPARATOR = '\n'
   , DEFAULT_ENCODING = 'utf-8';
@@ -21,7 +22,7 @@ module.exports.getVersion = function (filename) {
 	var ext = getExtension(filename)
     , result;
 
-  if (!~['js', 'json'].indexOf(ext)) {
+  if (!~['js', 'json', 'ts'].indexOf(ext)) {
     throw new Error('unsupported extension ' + ext);
   }
 
@@ -30,7 +31,12 @@ module.exports.getVersion = function (filename) {
     data = '(' + data + ')';
   }
 
-  result = patterns.parse(data);
+  if (ext === 'json' || ext === 'js') {
+    result = patterns.parse(data);
+  }
+  else if (ext === "ts") {
+    result = tspatterns.parse(filename, data);
+  }
 
   return result;
 };

--- a/package.json
+++ b/package.json
@@ -22,18 +22,21 @@
   },
   "main": "./index.js",
   "dependencies": {
+    "colors": "0.6.0-1",
     "optimist": "0.3.5",
     "semver": "1.1.2",
-    "uglify-js": "2.2.3",
-    "colors": "0.6.0-1"
+    "typescript": "^1.8.10",
+    "uglify-js": "2.2.3"
   },
   "devDependencies": {
-    "tap" : "~0.2.4"
+    "del": "^2.2.2",
+    "fs-extra": "^0.30.0",
+    "tap": "~0.2.4"
   },
   "bin": {
     "semver-sync": "./bin/semver-sync"
   },
-  "scripts" : {
-    "test" : "tap ./test/*.js --stderr"
+  "scripts": {
+    "test": "tap ./test/*.js --stderr"
   }
 }

--- a/patterns.js
+++ b/patterns.js
@@ -1,12 +1,12 @@
 var uglify = require('uglify-js');
 
 var isObjectLiteral = function (node) {
-  return node.start && node.end 
+  return node.start && node.end
       && node.start.value === '{' && node.end.value === '}';
 };
 
 var isJSONObject = function (node) {
-  return node.start && node.end 
+  return node.start && node.end
       && node.start.value === '(' && node.end.value === ')'
       && node.properties;
 }
@@ -31,7 +31,7 @@ var patterns = [];
 patterns.push(function (node) {
   // matching module.exports.version = '...' and exports.version = '...'
   // TODO: also matches module.version which is not quite OK
-  if (node.operator === '=' && node.left.property === 'version' 
+  if (node.operator === '=' && node.left.property === 'version'
     && ~['module', 'exports'].indexOf(node.left.start.value)) {
     return {
       version: node.right.end.value,
@@ -58,11 +58,11 @@ patterns.push(function (node) {
 });
 
 patterns.push(function (node) {
-  // matching generic assignments to .version or 
+  // matching generic assignments to .version or
   // literals containing the property 'version'
   var result;
   if (node.left && node.left.property === 'version') {
-    result = { 
+    result = {
       version: node.right.end.value,
       line: node.right.end.line
     }
@@ -73,7 +73,7 @@ patterns.push(function (node) {
   }
 
   if (result) {
-    console.log('WARNING: found version number ' + result.version + 
+    console.log('WARNING: found version number ' + result.version +
       ', but not directly assigned to module or exports.');
   }
   return result;

--- a/test/exec-invalid-test
+++ b/test/exec-invalid-test
@@ -6,3 +6,4 @@ cd tmp
 
 cp ../fixtures/package.json .
 cp ../fixtures/invalid.js .
+cp ../fixtures/invalid.ts .

--- a/test/fixtures/invalid.ts
+++ b/test/fixtures/invalid.ts
@@ -1,0 +1,11 @@
+export function foo () {
+}
+
+let bar = 1;
+
+if (bar === 2) {
+    console.log("Q");
+}
+
+const v = "0.0.1";
+export const version = v;

--- a/test/fixtures/tsmodule.ts
+++ b/test/fixtures/tsmodule.ts
@@ -1,0 +1,10 @@
+export function foo () {
+}
+
+let bar = 1;
+
+if (bar === 2) {
+    console.log("Q");
+}
+
+export const version = "0.0.1";

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,8 @@
 var exec = require('child_process').exec
   , test = require('tap').test
-  , sync = require('../');
+  , sync = require('../')
+  , del = require('del')
+  , fs = require('fs-extra');
 
 var getVersion = function (filename) {
   return sync.getVersion(filename).version;
@@ -16,6 +18,7 @@ test('reading version numbers from simple text fixtures', function (t) {
   t.equal(getVersion('fixtures/literal.js'), '0.10.29', "object literal returned from a module function");
   t.equal(getVersion('fixtures/assigned-literal.js'), '7.7.7', "object literal assigned to exports");
   t.equal(getVersion('fixtures/amd.js'), '0.9.0', "object literal assigned to exports in AMD-style module");
+  t.equal(getVersion('fixtures/tsmodule.ts'), '0.0.1', "exports from TypeScript module");
   t.end();
 });
 
@@ -29,6 +32,8 @@ test('reading version numbers from actual libraries', function (t) {
 test('version numbers come with line number information', function (t) {
   t.equal(getLine('fixtures/package.json'), 4, 'Line numbers work for JSON.');
   t.equal(getLine('fixtures/complete/topojson.js'), 248, 'Line number determined correctly for topojson.js.');
+  t.equal(getLine('fixtures/tsmodule.ts'), 10, "Line numbers work for TypeScript module.");
+
   t.end();
 });
 
@@ -43,6 +48,14 @@ test('setting version numbers', function (t) {
   sync.setVersion(['fixtures/complete/topojson.js'], '0.0.11');
   t.equal(getVersion('fixtures/complete/topojson.js'), '0.0.11', 'topojson.js parsed correctly.');
   sync.setVersion(['fixtures/complete/topojson.js'], '0.0.10');
+
+  del.sync(['tmp']);
+  fs.ensureDirSync('tmp');
+  fs.copySync('fixtures/tsmodule.ts', 'tmp/tsmodule.ts');
+  // Do it on a ts file.
+  t.equal(getVersion('tmp/tsmodule.ts'), '0.0.1');
+  sync.setVersion(['tmp/tsmodule.ts'], '0.10.0');
+  t.equal(getVersion('tmp/tsmodule.ts'), '0.10.0');
 
   t.end();
 });

--- a/tspatterns.js
+++ b/tspatterns.js
@@ -1,0 +1,43 @@
+var ts = require("typescript");
+
+function getLine(sourceFile, node) {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+    .line + 1; // + 1 because it is 0-based by default.
+}
+
+
+
+var exports = module.exports = {};
+
+exports.parse = function (filename, data) {
+  var sourceFile = ts.createSourceFile(filename, data);
+  var statements = sourceFile.statements;
+  for (var statementsIx = 0; statementsIx < statements.length; ++statementsIx) {
+    var statement = statements[statementsIx];
+    if (statement.kind !== ts.SyntaxKind.VariableStatement ||
+        statement.declarationList.kind !==
+        ts.SyntaxKind.VariableDeclarationList) {
+      continue;
+    }
+
+    var decls = statement.declarationList.declarations;
+    for (var declsIx = 0; declsIx < decls.length; ++declsIx)  {
+      var node = decls[declsIx];
+      if (node.kind !== ts.SyntaxKind.VariableDeclaration ||
+          node.name.text !== "version") {
+        continue;
+      }
+
+      var initializer = node.initializer;
+      if (initializer.kind !== ts.SyntaxKind.StringLiteral) {
+        continue;
+      }
+
+      // Bingo!
+      return {
+        version: initializer.text,
+        line: getLine(sourceFile, initializer),
+      };
+    }
+  }
+}


### PR DESCRIPTION
The main point of this branch is to add support for TypeScript.

There are two other changes on this branch in separate commits so that things can be cherry-picked if needed:
- I've removed the trailing whitespaces in patterns.js
- I've added an `.editorconfig`. It was automatically generated from the code already present. I eyeballed it and did not see any problems.

I've just noticed the tests failed on Node 0.8 and 0.6. Maybe it is time to stop supporting them?
